### PR TITLE
HIVE-28749: The default hikaricp.leakDetectionThreshold is not valid #5639

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/datasource/TestDataSourceProviderFactory.java
@@ -63,9 +63,27 @@ public class TestDataSourceProviderFactory {
   }
 
   @Test
-  public void testSetHikariCpLeakDetectionThresholdProperty() throws SQLException {
+  public void testDefaultHikariCpProperties() throws SQLException {
+    MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
+
+    DataSourceProvider dsp = DataSourceProviderFactory.tryGetDataSourceProviderOrNull(conf);
+    Assert.assertNotNull(dsp);
+
+    DataSource ds = dsp.create(conf);
+    Assert.assertTrue(ds instanceof HikariDataSource);
+    HikariDataSource hds = (HikariDataSource) ds;
+    Assert.assertEquals(30000L, hds.getConnectionTimeout());
+    Assert.assertEquals(1800000L, hds.getMaxLifetime());
+    Assert.assertEquals(0L, hds.getLeakDetectionThreshold());
+    Assert.assertEquals(1L, hds.getInitializationFailTimeout());
+  }
+
+  @Test
+  public void testSetHikariCpProperties() throws SQLException {
 
     MetastoreConf.setVar(conf, ConfVars.CONNECTION_POOLING_TYPE, HikariCPDataSourceProvider.HIKARI);
+    conf.set(HikariCPDataSourceProvider.HIKARI + ".connectionTimeout", "2000");
+    conf.set(HikariCPDataSourceProvider.HIKARI + ".maxLifetime", "50000");
     conf.set(HikariCPDataSourceProvider.HIKARI + ".leakDetectionThreshold", "3600");
     conf.set(HikariCPDataSourceProvider.HIKARI + ".initializationFailTimeout", "-1");
 
@@ -74,7 +92,11 @@ public class TestDataSourceProviderFactory {
 
     DataSource ds = dsp.create(conf);
     Assert.assertTrue(ds instanceof HikariDataSource);
-    Assert.assertEquals(3600L, ((HikariDataSource)ds).getLeakDetectionThreshold());
+    HikariDataSource hds = (HikariDataSource) ds;
+    Assert.assertEquals(2000L, hds.getConnectionTimeout());
+    Assert.assertEquals(50000L, hds.getMaxLifetime());
+    Assert.assertEquals(3600L, hds.getLeakDetectionThreshold());
+    Assert.assertEquals(-1L, hds.getInitializationFailTimeout());
   }
 
   @Test


### PR DESCRIPTION
What changes were proposed in this pull request?
HicariConfig's leak detection threshold has to be smaller than the max lifetime. Our default leak detection threshold is greater than the maximum lifetime defined on the HikariCP side and is disabled by default. Please check the JIRA for details.

https://issues.apache.org/jira/browse/HIVE-28749

Why are the changes needed?
Make our default value effective.

Does this PR introduce any user-facing change?
No.

Is the change a dependency upgrade?
No.

How was this patch tested?
I verified the warning disappears with default configurations
I tested hikaricp.maxLifetime was configurable in my local machine